### PR TITLE
chore(ci): add org-dependabot-auto-merge caller (v0.11.3)

### DIFF
--- a/.github/workflows/org-dependabot-auto-merge.yml
+++ b/.github/workflows/org-dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+name: Dependabot Auto-Merge
+
+# Evaluates Dependabot PRs for auto-merge eligibility using the org reusable
+# workflow: supply-chain checks (OSV + OpenSSF Scorecard), breaking-change
+# detection (semver + AI changelog analysis), then approves + auto-merges or
+# labels for manual review. Installed fleet-wide by the v0.8 unified wave.
+#
+# Uses pull_request_target (not pull_request) so the workflow has write
+# permissions on Dependabot PRs. The reusable workflow only reads metadata
+# from the PR branch, never executes code from it.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot-auto-merge.yml@9451b979c22b3762b3c8a7d4d9493fefaee7edc5 # v0.11.3
+    secrets: inherit


### PR DESCRIPTION
This repo was missing the fleet-standard Dependabot auto-merge caller, so its Dependabot PRs sat unmerged (found during the Actions v0.11.3 rollout status check). Content mirrors the fleet-standard caller (terraform-aws-kms), pinned to Actions v0.11.3 (9451b979).

🤖 Generated with [Claude Code](https://claude.com/claude-code)